### PR TITLE
Stop gracefully

### DIFF
--- a/chime-sdk-signaling-cpp/CHANGELOG.md
+++ b/chime-sdk-signaling-cpp/CHANGELOG.md
@@ -1,3 +1,13 @@
+# Unreleased
+
+## Fixed
+* Fixed stop behavior to end gracefully when stop is called.
+* Fixed handling of fragmented messages on libwebsockets
+
+## Changed
+* **Breaking** `Stop()` on `WebsocketSignalingTransport` no longer calls `StopRun`
+* `Runnable` now uses `atomic` to be thread-safe
+
 # 0.1.0 - 2022-08-19
 
 ## Added

--- a/chime-sdk-signaling-cpp/README.md
+++ b/chime-sdk-signaling-cpp/README.md
@@ -272,6 +272,9 @@ class MySignalingObserver: public SignalingClientObserver {
 }
 
 signaling_client.Stop();
+// Wait for OnSignalingStopped to be called
+// if you have called Run()
+signaling_client.StopRun();
 ```
 
 ## Debugging issues in C++ SDK signaling client

--- a/chime-sdk-signaling-cpp/src/signaling/default_signaling_client.cc
+++ b/chime-sdk-signaling-cpp/src/signaling/default_signaling_client.cc
@@ -469,7 +469,7 @@ void DefaultSignalingClient::HandleIndexFrame(const signal_rtc::IndexFrame& inde
 }
 
 DefaultSignalingClient::~DefaultSignalingClient() {
-  Stop();
+  Close();
 }
 
 DefaultSignalingClient::DefaultSignalingClient(SignalingClientConfiguration signaling_configuration,

--- a/chime-sdk-signaling-cpp/src/signaling/default_signaling_client.cc
+++ b/chime-sdk-signaling-cpp/src/signaling/default_signaling_client.cc
@@ -128,10 +128,10 @@ void DefaultSignalingClient::Close() {
 
 void DefaultSignalingClient::Stop() {
   CHIME_LOG(LogLevel::kInfo, "Stopping DefaultSignalingClient")
-  if (state_ == SignalingState::kConnected) SendLeave();
-  state_ = SignalingState::kDisconnecting;
+  if (state_ != SignalingState::kConnected) return;
   // Gracefully, shutting down if it is connected. It will call Close() to terminate when LEAVE_ACK is received.
   SendLeave();
+  state_ = SignalingState::kDisconnecting;
 }
 
 void DefaultSignalingClient::Poll() { signaling_transport_->Poll(); }

--- a/chime-sdk-signaling-cpp/src/signaling/default_signaling_client.h
+++ b/chime-sdk-signaling-cpp/src/signaling/default_signaling_client.h
@@ -77,6 +77,8 @@ class DefaultSignalingClient : public SignalingClient, public SignalingTransport
   bool SendJoin();
   bool SendLeave();
 
+  void Close();
+
   // Handle frame
   void UpdateTurnCredentials(const signal_rtc::JoinAckFrame& join_ack);
   bool TurnCredentialsExpired();

--- a/chime-sdk-signaling-cpp/src/transport/websocket_signaling_transport.cc
+++ b/chime-sdk-signaling-cpp/src/transport/websocket_signaling_transport.cc
@@ -27,7 +27,6 @@ void WebsocketSignalingTransport::Stop() {
   if (is_stopped_) return;
   CHIME_LOG(LogLevel::kInfo, "Stopping Signaling Transport")
 
-  websocket_->StopRun();
   websocket_->Close();
 }
 
@@ -96,7 +95,7 @@ void WebsocketSignalingTransport::OnWebsocketClosed(WebsocketStatus status) {
 
 void WebsocketSignalingTransport::OnWebsocketError(WebsocketErrorStatus error) {
   is_stopped_ = true;
-
+  CHIME_LOG(LogLevel::kInfo, "Nick: OnWebsocketError")
   SignalingError signaling_error{SignalingErrorType::kClientFatalError, error.description};
   observer_->OnSignalingErrorReceived(signaling_error);
 }

--- a/chime-sdk-signaling-cpp/src/transport/websocket_signaling_transport.cc
+++ b/chime-sdk-signaling-cpp/src/transport/websocket_signaling_transport.cc
@@ -95,7 +95,6 @@ void WebsocketSignalingTransport::OnWebsocketClosed(WebsocketStatus status) {
 
 void WebsocketSignalingTransport::OnWebsocketError(WebsocketErrorStatus error) {
   is_stopped_ = true;
-  CHIME_LOG(LogLevel::kInfo, "Nick: OnWebsocketError")
   SignalingError signaling_error{SignalingErrorType::kClientFatalError, error.description};
   observer_->OnSignalingErrorReceived(signaling_error);
 }

--- a/chime-sdk-signaling-cpp/test/src/signaling/default_signaling_client_tests.cc
+++ b/chime-sdk-signaling-cpp/test/src/signaling/default_signaling_client_tests.cc
@@ -69,8 +69,8 @@ TEST_F(DefaultSignalingClientTest, ShouldCallSendLeave) {
       std::move(dependencies)
   };
 
-  // Join
-  EXPECT_CALL(*mock_signaling_transport_ref, SendSignalFrame).Times(1);
+  // Join + Leave
+  EXPECT_CALL(*mock_signaling_transport_ref, SendSignalFrame).Times(2);
   client.OnSignalingConnected();
 
   client.Stop();

--- a/chime-sdk-signaling-cpp/test/src/signaling/default_signaling_client_tests.cc
+++ b/chime-sdk-signaling-cpp/test/src/signaling/default_signaling_client_tests.cc
@@ -69,8 +69,8 @@ TEST_F(DefaultSignalingClientTest, ShouldCallSendLeave) {
       std::move(dependencies)
   };
 
-  // Join + Leave
-  EXPECT_CALL(*mock_signaling_transport_ref, SendSignalFrame).Times(2);
+  // Join
+  EXPECT_CALL(*mock_signaling_transport_ref, SendSignalFrame).Times(1);
   client.OnSignalingConnected();
 
   client.Stop();
@@ -104,8 +104,8 @@ TEST_F(DefaultSignalingClientTest, ShouldCallSendSignalFrameWhenConnected) {
   };
 
   // Make the state to be connected
-  // Update + Join + Leave
-  EXPECT_CALL(*mock_signaling_transport_ref, SendSignalFrame).Times(3);
+  // Update + Join
+  EXPECT_CALL(*mock_signaling_transport_ref, SendSignalFrame).Times(2);
   client.OnSignalingConnected();
 
   client.SendUpdates();
@@ -139,8 +139,8 @@ TEST_F(DefaultSignalingClientTest, ShouldCallSendJoinWhenConnected) {
   };
 
   // Make the state to be connected
-  // Join + Leave when destructed
-  EXPECT_CALL(*mock_signaling_transport_ref, SendSignalFrame).Times(2);
+  // Join
+  EXPECT_CALL(*mock_signaling_transport_ref, SendSignalFrame).Times(1);
 
   client.OnSignalingConnected();
 }
@@ -175,8 +175,8 @@ TEST_F(DefaultSignalingClientTest, ShouldCallSendDataMessageWhenSendDataMessage)
       configuration,
       std::move(dependencies)
   };
-  // Join + data message + leave
-  EXPECT_CALL(*mock_signaling_transport_ref, SendSignalFrame).Times(3);
+  // Join + data message
+  EXPECT_CALL(*mock_signaling_transport_ref, SendSignalFrame).Times(2);
   
   client.OnSignalingConnected();
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This is to wait for `LEAVE_ACK`, so that the signaling client ends more gracefully.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
