### PR TITLE
Make webrtc path settable by user

### DIFF
--- a/chime-sdk-signaling-cpp/demo/cli/CMakeLists.txt
+++ b/chime-sdk-signaling-cpp/demo/cli/CMakeLists.txt
@@ -9,7 +9,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CLI_NAME my_cli)
 set(WORKSPACE_SRC "${CMAKE_CURRENT_SOURCE_DIR}/../../../.." CACHE INTERNAL "Path to the workspace containing this project and its internal dependencies")
 set(CHIME_SIGNAL_SRC "${CMAKE_CURRENT_SOURCE_DIR}/../..")
-set(VANILLA_WEBRTC_SRC "${WORKSPACE_SRC}/webrtc-build")
+set(VANILLA_WEBRTC_SRC "${WORKSPACE_SRC}/webrtc-build" CACHE STRING "Path to webRTC folder")
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 
 if(NOT CMAKE_BUILD_TYPE)


### PR DESCRIPTION
*Issue #, if available:*
*Description of changes:*
Make `VANILLA_WEBRTC_SRC` settable by user. Now this will allow you to do
```
-DVANILLA_WEBRTC_SRC="path-to-webrtc"
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
